### PR TITLE
Agregar fila de área necesaria en resultados del cotizador

### DIFF
--- a/src/components/Cotizadorfactura.jsx
+++ b/src/components/Cotizadorfactura.jsx
@@ -323,6 +323,13 @@ const CotizadorFactura = () => {
         ["Consumo mensual", `${resultado.consumo_kwh} kWh`],
         ["Potencia requerida", `${resultado.potencia_kwp} kWp`],
         ["Número de paneles", `${resultado.numero_paneles}`],
+        [
+          "Área necesaria",
+          `${(Number(resultado.numero_paneles || 0) * 2.6).toLocaleString("es-CO", {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 1,
+          })} m²`,
+        ],
         ["Inversor", `${resultado.inversor_utilizado}`],
         [
           "Generación mensual",
@@ -620,6 +627,15 @@ oferta formal y posterior firma de contrato.
                 <tr><td>🔌 Tipo de servicio</td><td>{resultado.tipo_servicio}</td></tr>
                 <tr><td>⚡ Consumo mensual</td><td>{Number(resultado.consumo_kwh).toFixed(0)} kWh</td></tr>
                 <tr className="table-success"><td>📦 Número de paneles</td><td>{resultado.numero_paneles}</td></tr>
+                <tr className="table-success">
+                  <td>📐 Área necesaria</td>
+                  <td>
+                    {(Number(resultado.numero_paneles || 0) * 2.6).toLocaleString("es-CO", {
+                      minimumFractionDigits: 1,
+                      maximumFractionDigits: 1,
+                    })} m²
+                  </td>
+                </tr>
                 <tr className="table-success"><td>⚙️ Inversor</td><td>{resultado.inversor_utilizado}</td></tr>
                 <tr className="table-success">
                   <td>💰 Precio estimado</td>


### PR DESCRIPTION
### Motivation
- Mostrar en la interfaz y en el PDF la "Área necesaria" para la instalación derivada del número de paneles usando un factor de 2,6 m² por panel según lo solicitado.

### Description
- Se añadió una fila `Área necesaria` en la tabla HTML de resultados dentro de `src/components/Cotizadorfactura.jsx` que muestra `número_de_paneles * 2.6 m²`.
- Se incorporó la misma fila en la tabla de "Resultados Técnicos" del PDF generado por `exportarPDF()` empleando `autoTable` para mantener consistencia entre UI y documento.
- El valor se calcula con `Number(resultado.numero_paneles || 0) * 2.6` y se formatea usando `.toLocaleString("es-CO")` con 1 decimal.

### Testing
- Se ejecutó `npm run build` y el build de Vite finalizó correctamente (sin errores).
- Se corrió un script automatizado de navegador (Playwright) que navegó hasta la página, rellenó el formulario y generó una captura de pantalla del bloque de resultados, produciendo el artefacto de comprobación (screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947ed4c4ec832894485a54d66886ea)